### PR TITLE
英語訳を洗練させ、EULAの英語訳を追加しました

### DIFF
--- a/src-tauri/eula.txt
+++ b/src-tauri/eula.txt
@@ -1,10 +1,7 @@
-エンドユーザー使用許諾契約書（EULA)
-End User License Agreement (EULA)
+エンドユーザー使用許諾契約書（EULA）
 
-Copyright (c) 2025 Neosku
-[Note to English users: An English version of the EULA can be found below the Japanese translation.]
+Copyright (c) 2025-2026 Neosku
 
-[ 日本語 / Japanese ]
 本ソフトウェアをインストールまたは使用する前に、本使用許諾契約書（以下「本契約」といいます。）をよくお読みください。
 本ソフトウェアをインストールまたは使用した時点で、利用者（以下「ユーザー」といいます。）は本契約の内容に同意したものとみなされます。
 
@@ -32,9 +29,9 @@ Copyright (c) 2025 Neosku
 
 1. 本ソフトウェアは、人気順の算出を目的として、利用状況に関する情報（以下「統計情報」といいます。）を作者が管理するサーバーへ送信することがあります。
 2. 統計情報には、例えば次の情報が含まれます。
-   (1) インストールまたはアンインストールしたパッケージのID
-   (2) インストール済みのパッケージID
-   (3) 送信日時およびランダムに生成された識別子
+   1. インストールまたはアンインストールしたパッケージのID
+   2. インストール済みのパッケージID
+   3. 送信日時およびランダムに生成された識別子
 3. 作者は、統計情報を個人を特定する目的で利用しません。作者は、統計情報を集計その他の処理を行った上で、人気順の表示等のために利用します。
 4. ユーザーは、設定画面により、統計情報の送信を有効または無効に設定できます。
 5. 作者は、統計情報の漏えい、滅失または毀損の防止その他の安全管理のため、合理的な措置を講じます。
@@ -47,45 +44,3 @@ Copyright (c) 2025 Neosku
 すでにインストールしている場合は、直ちに本ソフトウェアをアンインストールしてください。
 
 以上
-
-[ 英語 / English ]
-Please read this License Agreement (hereinafter referred to as “this Agreement”) carefully before installing or using this software.
-By installing or using this software, the user (hereinafter referred to as “the User”) is deemed to have agreed to the terms of this Agreement.
-
-### Article 1 (About the Software)
-
-1. This Software is a utility designed to facilitate the installation of plugins and scripts for AviUtl2.
-2. This Software is provided under the MIT License.
-3. This Agreement sets forth additional precautions and disclaimers regarding the use of this Software.
-
-### Article 2 (Regarding Plugins and Scripts)
-
-1. This Software provides functions to assist in the download and installation of plugins and scripts available on the Internet; it does not provide or guarantee the plugins and scripts themselves.
-2. Users shall comply with the respective licenses, terms of use, and agreements established for each plugin and script installed through this software.
-
-### Article 3 (User Responsibility)
-
-1. Users shall bear all responsibility, at their own risk and expense, for the use, modification, redistribution, and other actions related to plugins and scripts.
-2. The author of this software shall not be liable in any way even if the user violates the license or other terms of any plugin or script.
-
-### Article 4 (Disclaimer)
-
-1. The author shall not be liable for any damages arising from the use or inability to use this software, regardless of the reason.
-
-### Article 5 (Collection and Transmission of Statistical Information)
-
-1. For the purpose of calculating popularity rankings, this software may transmit information regarding usage (hereinafter referred to as “statistical information”) to a server managed by the author.
-2. Statistical information includes, for example, the following:
-   (1) The ID of installed or uninstalled packages
-   (2) The IDs of installed packages
-   (3) The date and time of transmission and a randomly generated identifier
-3. The Author will not use statistical information for the purpose of identifying individuals. The Author will aggregate and otherwise process statistical information and use it for purposes such as displaying popularity rankings.
-4. Users may enable or disable the transmission of statistical information by accessing the Settings menu.
-5. The Author will take reasonable measures to prevent the leakage, loss, or damage of statistical information and to ensure its security.
-6. The Author will not provide statistical information to third parties, unless if strictly required by law.
-
-
-### Article 6 (Termination of Agreement)
-
-If you do not agree to this Agreement, you must not install or use this software.
-If you have already installed the Software, please uninstall it immediately.

--- a/src-tauri/eula.txt
+++ b/src-tauri/eula.txt
@@ -1,7 +1,10 @@
-エンドユーザー使用許諾契約書（EULA）
+エンドユーザー使用許諾契約書（EULA)
+End User License Agreement (EULA)
 
 Copyright (c) 2025 Neosku
+[Note to English users: An English version of the EULA can be found below the Japanese translation.]
 
+[ 日本語 / Japanese ]
 本ソフトウェアをインストールまたは使用する前に、本使用許諾契約書（以下「本契約」といいます。）をよくお読みください。
 本ソフトウェアをインストールまたは使用した時点で、利用者（以下「ユーザー」といいます。）は本契約の内容に同意したものとみなされます。
 
@@ -44,3 +47,45 @@ Copyright (c) 2025 Neosku
 すでにインストールしている場合は、直ちに本ソフトウェアをアンインストールしてください。
 
 以上
+
+[ 英語 / English ]
+Please read this License Agreement (hereinafter referred to as “this Agreement”) carefully before installing or using this software.
+By installing or using this software, the user (hereinafter referred to as “the User”) is deemed to have agreed to the terms of this Agreement.
+
+### Article 1 (About the Software)
+
+1. This Software is a utility designed to facilitate the installation of plugins and scripts for AviUtl2.
+2. This Software is provided under the MIT License.
+3. This Agreement sets forth additional precautions and disclaimers regarding the use of this Software.
+
+### Article 2 (Regarding Plugins and Scripts)
+
+1. This Software provides functions to assist in the download and installation of plugins and scripts available on the Internet; it does not provide or guarantee the plugins and scripts themselves.
+2. Users shall comply with the respective licenses, terms of use, and agreements established for each plugin and script installed through this software.
+
+### Article 3 (User Responsibility)
+
+1. Users shall bear all responsibility, at their own risk and expense, for the use, modification, redistribution, and other actions related to plugins and scripts.
+2. The author of this software shall not be liable in any way even if the user violates the license or other terms of any plugin or script.
+
+### Article 4 (Disclaimer)
+
+1. The author shall not be liable for any damages arising from the use or inability to use this software, regardless of the reason.
+
+### Article 5 (Collection and Transmission of Statistical Information)
+
+1. For the purpose of calculating popularity rankings, this software may transmit information regarding usage (hereinafter referred to as “statistical information”) to a server managed by the author.
+2. Statistical information includes, for example, the following:
+   (1) The ID of installed or uninstalled packages
+   (2) The IDs of installed packages
+   (3) The date and time of transmission and a randomly generated identifier
+3. The Author will not use statistical information for the purpose of identifying individuals. The Author will aggregate and otherwise process statistical information and use it for purposes such as displaying popularity rankings.
+4. Users may enable or disable the transmission of statistical information by accessing the Settings menu.
+5. The Author will take reasonable measures to prevent the leakage, loss, or damage of statistical information and to ensure its security.
+6. The Author will not provide statistical information to third parties, unless if strictly required by law.
+
+
+### Article 6 (Termination of Agreement)
+
+If you do not agree to this Agreement, you must not install or use this software.
+If you have already installed the Software, please uninstall it immediately.

--- a/src/i18n/resources/en/common.json
+++ b/src/i18n/resources/en/common.json
@@ -2,8 +2,8 @@
   "appName": "AviUtl2 Catalog",
   "router": {
     "loading": "Loading...",
-    "notFoundTitle": "Page not found",
-    "notFoundDescription": "The page you requested does not exist or has moved.",
+    "notFoundTitle": "Page Not Found",
+    "notFoundDescription": "The page you requested does not exist or has been moved.",
     "goHome": "Back to package list"
   },
   "actions": {
@@ -46,30 +46,30 @@
   },
   "packageTypes": {
     "core": "Core",
-    "mod": "MOD",
-    "inputPlugin": "Input plugin",
-    "outputPlugin": "Output plugin",
-    "generalPlugin": "General plugin",
-    "filterPlugin": "Filter plugin",
+    "mod": "Mod",
+    "inputPlugin": "Input Plugins",
+    "outputPlugin": "Output Plugins",
+    "generalPlugin": "General Plugins",
+    "filterPlugin": "Filter Plugins",
     "script": "Script",
     "other": "Other"
   },
   "errors": {
     "unknown": "Unknown error",
-    "submitFailed": "Submission failed. Check your network connection and configuration.",
+    "submitFailed": "Submission failed. Please check your Internet connection.",
     "submitEndpointRequired": "VITE_SUBMIT_ENDPOINT is not configured.",
     "submitEndpointHttps": "VITE_SUBMIT_ENDPOINT must start with https://."
   },
   "submit": {
-    "successDefault": "Submission completed.",
+    "successDefault": "Submission completed!",
     "completeTitle": "Submitted"
   },
   "process": {
     "checkFailed": "Could not check whether AviUtl2 is running: {{detail}}",
-    "running": "AviUtl2 is running.\nClose the app before installing or uninstalling packages."
+    "running": "AviUtl2 is running!\nClose the app before installing or uninstalling packages."
   },
   "github": {
-    "rateLimit": "GitHub API primary rate limit reached. Retry after {{resetAt}}."
+    "rateLimit": "You have been ratelimited by GitHub's API. Retry after {{resetAt}}."
   },
   "markdownAlerts": {
     "note": "Note",
@@ -92,8 +92,8 @@
     "notesUnavailable": "Release notes are unavailable.",
     "later": "Later",
     "updating": "Updating...",
-    "updateNow": "Update now",
-    "appliedMessage": "The update was applied. Please restart the app.",
+    "updateNow": "Update Now",
+    "appliedMessage": "Update applied! Please restart the app.",
     "failed": "The update failed. Check your network connection and permissions."
   },
   "windowControls": {
@@ -109,7 +109,7 @@
     },
     "errors": {
       "aviutlFolderRequired": "Please select the AviUtl2 folder.",
-      "packageIdEmpty": "Package ID is empty.",
+      "packageIdEmpty": "The package ID is empty.",
       "aviutlExeNotFound": "aviutl2.exe was not found: {{path}}",
       "launchAviutlFailed": "Failed to launch AviUtl2: {{detail}}",
       "exedit2NotInstalled": "Kenkun.AviUtlExEdit2 is not installed. Install it and try again.",

--- a/src/i18n/resources/en/common.json
+++ b/src/i18n/resources/en/common.json
@@ -4,7 +4,7 @@
     "loading": "Loading...",
     "notFoundTitle": "Page Not Found",
     "notFoundDescription": "The page you requested does not exist or has been moved.",
-    "goHome": "Back to package list"
+    "goHome": "Back to Package List"
   },
   "actions": {
     "close": "Close",

--- a/src/i18n/resources/en/feedback.json
+++ b/src/i18n/resources/en/feedback.json
@@ -2,27 +2,27 @@
   "header": {
     "title": "Feedback",
     "description": "Send bug reports and feedback.",
-    "issuesLink": "Reported issues"
+    "issuesLink": "Issues Page (GitHub)"
   },
   "shared": {
     "optional": "(Optional)",
     "loading": "Collecting information..."
   },
   "modes": {
-    "bug": "Bug report",
-    "inquiry": "Feedback / inquiry"
+    "bug": "Bug Report",
+    "inquiry": "Feedback / Inquiry"
   },
   "visibility": {
     "public": "Public",
     "private": "Private",
-    "publicTitle": "Public visibility",
-    "privateTitle": "Private visibility",
-    "publicDescription": "<strong>Title</strong> and <strong>details</strong> will be public. Contact details, attachments, device info, and other metadata remain private.",
+    "publicTitle": "Public Report",
+    "privateTitle": "Private Report",
+    "publicDescription": "The <strong>title</strong> and <strong>description</strong> of your report will be public.\nOther information such as contact details, attachments, and device info will remain private.",
     "privateDescription": "Feedback and inquiries are not published. Only the developer can review them."
   },
   "fields": {
     "title": "Title",
-    "detail": "Details",
+    "detail": "Description",
     "contact": "Contact",
     "bugTitlePlaceholder": "Describe the bug briefly",
     "bugDetailPlaceholder": "Explain what happened, how to reproduce it, and what you expected",
@@ -43,27 +43,27 @@
     "unknownVersion": "Unknown",
     "driver": "Driver",
     "cores": "Cores",
-    "logical": "Logical",
+    "logical": "Logical processors",
     "maxClock": "Max clock",
     "unavailable": "Device information could not be collected."
   },
   "log": {
     "title": "Log file",
     "include": "Attach app.log",
-    "unavailable": "The log could not be retrieved."
+    "unavailable": "Log could not be retrieved."
   },
   "submit": {
     "sending": "Sending..."
   },
   "messages": {
-    "bugSuccess": "Your bug report has been sent. Thank you.",
-    "inquirySuccess": "Your feedback has been sent. Thank you."
+    "bugSuccess": "Your bug report has been sent. Thank you!",
+    "inquirySuccess": "Your feedback has been sent. Thank you!"
   },
   "errors": {
-    "requiredFields": "Title and details are required."
+    "requiredFields": "Please provide the title and description of your report."
   },
   "payload": {
-    "bugTitlePrefix": "Bug report",
+    "bugTitlePrefix": "Bug Report",
     "inquiryTitlePrefix": "Inquiry"
   }
 }

--- a/src/i18n/resources/en/initSetup.json
+++ b/src/i18n/resources/en/initSetup.json
@@ -1,51 +1,51 @@
 {
   "intro": {
     "title": "AviUtl2 Catalog",
-    "description": "Configure AviUtl2 Catalog for first use",
-    "start": "Start setup"
+    "description": "Configure AviUtl2 Catalog for first-time use",
+    "start": "Start Setup"
   },
   "steps": {
     "intro": "Start",
-    "installStatus": "Setup status",
-    "detailsExisting": "Review settings",
+    "installStatus": "Setup Status",
+    "detailsExisting": "Review Settings",
     "detailsInstall": "Install",
-    "packages": "Recommended packages"
+    "packages": "Recommended Packages"
   },
   "installStatus": {
-    "title": "Install status",
-    "description": "Choose the option that matches your AviUtl2 setup",
-    "installedTitle": "Already installed",
-    "installedDescription": "Use this if AviUtl2 is already installed",
-    "freshTitle": "Fresh install",
-    "freshDescription": "Use this if AviUtl2 is not installed yet.\nThe latest version will be downloaded and installed automatically."
+    "title": "Install Status",
+    "description": "Choose the option that matches your AviUtl2 setup.",
+    "installedTitle": "Existing Install",
+    "installedDescription": "Use this if AviUtl2 is already installed.",
+    "freshTitle": "Start from Scratch",
+    "freshDescription": "Use this if AviUtl2 isn't installed yet.\nThe latest version will be downloaded and installed for you."
   },
   "details": {
-    "portableMode": "Portable mode",
+    "portableMode": "Install Method",
     "standard": "Standard (Recommended)",
     "portable": "Portable",
     "standardDescription": "Install plugins and scripts into ProgramData.",
     "portableDescription": "Install plugins and scripts into the data folder next to aviutl2.exe.",
     "existing": {
-      "title": "Choose folder",
+      "title": "Choose Folder",
       "description": "Select the folder where AviUtl2 is already installed",
-      "label": "AviUtl2 folder path",
+      "label": "AviUtl2 Folder Path",
       "hint": "Select the folder that contains aviutl2.exe"
     },
     "install": {
-      "title": "Choose install location",
-      "description": "Select the folder where AviUtl2 should be installed",
+      "title": "Install Location",
+      "description": "Select the folder where AviUtl2 should be installed.",
       "label": "Install folder",
-      "next": "Install and continue",
+      "next": "Install and Continue",
       "installing": "Installing...",
-      "progressAria": "Installation progress"
+      "progressAria": "Installation progress:"
     }
   },
   "packages": {
-    "title": "Recommended packages",
+    "title": "Recommended Packages",
     "allInstalled": "All recommended packages are already installed",
-    "description": "Install the core plugins needed for standard use",
+    "description": "Installs the core plugins needed for standard use",
     "loading": "Loading package information...",
-    "missingSummary": "Failed to load detailed information",
+    "missingSummary": "Failed to load detailed information.",
     "progressAria": "Progress for {{name}}",
     "installed": "Installed",
     "notInstalled": "Not installed",
@@ -53,22 +53,22 @@
     "installAndNext": "Install all and continue"
   },
   "done": {
-    "title": "Setup complete",
-    "description": "All settings are ready",
+    "title": "Setup complete!",
+    "description": "All settings have been set, have fun!",
     "openApp": "Open AviUtl2 Catalog"
   },
   "errors": {
     "aviutlRootRequired": "Please enter the AviUtl2 folder.",
-    "saveFailed": "Failed to save the settings.",
+    "saveFailed": "Failed to save settings.",
     "installDirRequired": "Please enter an installation folder.",
     "setupFailed": "Setup failed.",
-    "installFailed": "Installation failed.",
-    "bulkInstallPartialFailed": "Some installations failed.",
+    "installFailed": "Package failed to install. (Is AviUtl2 running?)",
+    "bulkInstallPartialFailed": "Some packages failed to install. (Is AviUtl2 running?)",
     "generic": "An error occurred.",
     "packageInfoPartialFailed": "Could not load some package information: {{ids}}",
     "requiredPackagesLoadFailed": "Could not load the required package information.",
     "packageInfoMissing": "Package information was not found: {{id}}",
-    "networkRequired": "Please connect to the internet.",
+    "networkRequired": "An Internet connection is required.",
     "packageInfoUnavailable": "Could not fetch the package information.",
     "packageNotInstallable": "This package cannot be installed.",
     "pickInstallDir": "Choose install folder",

--- a/src/i18n/resources/en/links.json
+++ b/src/i18n/resources/en/links.json
@@ -1,7 +1,7 @@
 {
   "page": {
     "title": "Links",
-    "description": "Access related sites and support resources"
+    "description": "Access related sites and support resources\n(Note: Some information may be only available in Japanese.)"
   },
   "sections": {
     "official": {
@@ -28,15 +28,15 @@
   "entries": {
     "official-site": {
       "title": "Official site",
-      "description": "The official AviUtl2 site"
+      "description": "The official site of AviUtl2 (Japanese only)"
     },
     "official-changelog": {
       "title": "Changelog (by Nanashi.)",
-      "description": "An unofficial site for checking AviUtl2 release history"
+      "description": "An unofficial site for checking AviUtl2's release history (Japanese only)"
     },
     "community-discord": {
       "title": "Discord",
-      "description": "An unofficial Discord community for AviUtl2 discussions and questions"
+      "description": "An unofficial Discord community for discussions and questions regarding AviUtl2"
     },
     "support-feedback": {
       "title": "Feedback",
@@ -44,7 +44,7 @@
     },
     "support-register": {
       "title": "Package registration",
-      "description": "Form for adding new packages or updating existing entries"
+      "description": "Form for adding new packages to the catalog, or updating existing entries"
     },
     "developers-register-guide": {
       "title": "How to publish a package",

--- a/src/i18n/resources/en/nav.json
+++ b/src/i18n/resources/en/nav.json
@@ -1,21 +1,21 @@
 {
   "navigation": {
-    "home": "Package list",
-    "updates": "Update center",
+    "home": "Package List",
+    "updates": "Update Center",
     "links": "Links",
     "niconiCommons": "Niconi Commons",
-    "register": "Package registration",
+    "register": "Package Registration",
     "feedback": "Feedback",
     "settings": "Settings"
   },
   "sections": {
-    "mainMenu": "Main menu",
+    "mainMenu": "Main Menu",
     "shortcuts": "Shortcuts"
   },
   "items": {
     "launchAviutl2": "Launch AviUtl2",
-    "openDataDir": "Open data folder",
-    "openSidebar": "Open sidebar",
-    "closeSidebar": "Close sidebar"
+    "openDataDir": "Open Data Folder",
+    "openSidebar": "Open Sidebar",
+    "closeSidebar": "Close Sidebar"
   }
 }

--- a/src/i18n/resources/en/niconiCommons.json
+++ b/src/i18n/resources/en/niconiCommons.json
@@ -10,13 +10,13 @@
   "guide": {
     "title": "What is a Niconi Commons ID?",
     "body": "Niconi Commons is a service that helps creators collaborate and safely reuse each other's work.\nOn Niconico, you can register the tools and assets used to make your work, such as AviUtl2, plugins, scripts, and materials, as parent works to build a content tree.\nRegistering parent works when posting a video lets the creators of those tools and assets know they are appreciated and supports their work.\nNiconico also provides systems that can lead to financial support for creators.\nPlease consider registering parent works for the tools and assets you use.",
-    "note": "Note: registering parent works does not reduce your own revenue.",
-    "open": "How to register parent works"
+    "note": "Note: Registering parent works does not reduce your own revenue. Niconi Commons is only available in Japan.",
+    "open": "How to register parent works (Japanese only)"
   },
   "toolbar": {
     "visible": "Visible: {{count}}",
     "selected": "Selected: {{count}}",
-    "searchPlaceholder": "Package name / ID / author / Commons ID"
+    "searchPlaceholder": "Package Name / ID / Author / Commons ID"
   },
   "table": {
     "emptyEligible": "There are no eligible packages.",

--- a/src/i18n/resources/en/register/workflow.json
+++ b/src/i18n/resources/en/register/workflow.json
@@ -15,8 +15,8 @@
     "body": "All plugin information entered in this form will be public.\nAnyone can register a package, even if they are not the original author."
   },
   "sidebar": {
-    "newPackage": "Create package",
-    "pendingList": "Pending submissions",
+    "newPackage": "Create Package",
+    "pendingList": "Pending Submissions",
     "pendingReady": "Ready to submit",
     "draftStatusNotRequired": "No test required",
     "draftStatusReady": "Tested",
@@ -36,15 +36,15 @@
   },
   "preview": {
     "title": "Preview",
-    "switchToLight": "Switch to light mode",
-    "switchToDark": "Switch to dark mode",
-    "fallbackName": "Package name",
+    "switchToLight": "Switch to Light Mode",
+    "switchToDark": "Switch to Dark Mode",
+    "fallbackName": "Package Name",
     "fallbackAuthor": "Author",
     "fallbackSummary": "The summary appears here"
   },
   "jsonImport": {
     "title": "JSON input",
-    "description": "Paste JSON in the same format as template.json. Matching items will be partially overwritten, and unmatched ids will be added as new entries. You can add multiple packages at once.",
+    "description": "Paste your JSON file in the same format as template.json. Matching items will be partially overwritten, and unmatched IDs will be added as new entries. You can add multiple packages at once.",
     "placeholder": "[\n  {\n    \"id\": \"author.pluginName\",\n    \"name\": \"Example Plugin\",\n    \"type\": \"Input plugin\",\n    \"summary\": \"A short package summary goes here.\"\n  },\n  {\n    \"id\": \"author.scriptName\",\n    \"name\": \"Example Script\",\n    \"type\": \"Script\",\n    \"summary\": \"A short script summary goes here.\"\n  }\n]",
     "cancel": "Cancel",
     "apply": "Apply"

--- a/src/i18n/resources/en/settings.json
+++ b/src/i18n/resources/en/settings.json
@@ -4,38 +4,38 @@
     "description": "Configure and customize the application"
   },
   "sections": {
-    "app": "App settings",
-    "dataManagement": "Data management",
-    "appInfo": "App info"
+    "app": "App Settings",
+    "dataManagement": "Data Management",
+    "appInfo": "App Info"
   },
   "app": {
     "aviutl2Root": {
-      "label": "AviUtl2 folder",
+      "label": "AviUtl2 Folder",
       "description": "Select the folder that contains aviutl2.exe.",
       "placeholder": "Folder containing aviutl2.exe",
       "dialogTitle": "AviUtl2 root folder"
     },
     "language": {
-      "label": "Display language",
+      "label": "Display Language",
       "description": "Choose the language used for the app UI."
     },
     "portableMode": {
-      "title": "Portable mode",
-      "recommendedOff": "Recommended: Off",
-      "description": "Store plugins and scripts in the data folder next to aviutl2.exe."
+      "title": "Portable Mode",
+      "recommendedOff": "Recommended: OFF",
+      "description": "Stores installed plugins and scripts in the data folder next to aviutl2.exe."
     },
     "theme": {
-      "title": "Dark mode"
+      "title": "Dark Mode"
     },
     "packageState": {
       "title": "Send anonymous usage statistics",
       "description": "To improve app recommendations, anonymously send installed and uninstalled package IDs along with the currently installed package IDs."
     },
-    "save": "Save settings",
+    "save": "Save Settings",
     "saved": "Saved"
   },
   "dataManagement": {
-    "packages": "Export / import package list",
+    "packages": "Export / Import Package List",
     "export": "Export",
     "import": "Import",
     "status": {
@@ -88,6 +88,6 @@
     "directoryPickFailed": "Failed to select a directory.",
     "aviutl2Required": "Please select the AviUtl2 folder.",
     "languageApplyFailed": "The settings were saved, but the display language could not be applied immediately.",
-    "saveFailed": "Failed to save settings. Check permissions and the path."
+    "saveFailed": "Failed to save settings. Check the app permissions and path."
   }
 }


### PR DESCRIPTION
ボタンの表記を一部修正し、大文字小文字を適切に統一しました。また、利用許諾契約書（EULA）の英語訳も適切なものに修正されました。
A few words have been tweaked to add proper capitalization to buttons (including a few minor tweaks for clarity), and the EULA now has a proper English translation.

問題が生じた場合は、至急ご連絡ください。
If there are any issues with this PR, please contact me.